### PR TITLE
Update log location

### DIFF
--- a/ctor/etc/nginx/sites-available/default
+++ b/ctor/etc/nginx/sites-available/default
@@ -13,7 +13,7 @@ server {
                 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
                 proxy_set_header X-Forwarded-Proto $scheme;
                 proxy_http_version 1.1;
-                proxy_pass http://0xd34df00d.me/logs/chat/;
+                proxy_pass https://chatlogs.jabber.ru/;
 	}
 
 


### PR DESCRIPTION
This PR updates the log proxy location from http://0xd34df00d.me to https://chatlogs.jabber.ru/.

**Scope**: #16.

**Status**: already applied, but feel free to discuss if you think that something's wrong.