### PR TITLE
#16: host old logs directly on our server

### DIFF
--- a/ctor/etc/nginx/sites-available/default
+++ b/ctor/etc/nginx/sites-available/default
@@ -1,37 +1,41 @@
 server {
-        listen 443 ssl;
-        server_name codingteam.org.ru;
-        keepalive_timeout 60;
-        ssl_certificate /etc/letsencrypt/live/loglist.net/fullchain.pem;
-        ssl_certificate_key /etc/letsencrypt/live/loglist.net/privkey.pem;
-        ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-        ssl_ciphers  "HIGH:!aNULL:!MD5:!kEDH";
-        add_header Strict-Transport-Security 'max-age=15552000';
+    listen 443 ssl;
+    server_name codingteam.org.ru;
+    keepalive_timeout 60;
+    ssl_certificate /etc/letsencrypt/live/loglist.net/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/loglist.net/privkey.pem;
+    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+    ssl_ciphers  "HIGH:!aNULL:!MD5:!kEDH";
+    add_header Strict-Transport-Security 'max-age=15552000';
 
-	location /_logs/ {
-		proxy_set_header X-Forwarded-Host $host;
-                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-                proxy_set_header X-Forwarded-Proto $scheme;
-                proxy_http_version 1.1;
-                proxy_pass https://chatlogs.jabber.ru/;
-	}
+    location /_logs/ {
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_http_version 1.1;
+        proxy_pass https://chatlogs.jabber.ru/;
+    }
 
+    location /old-logs/ {
+        alias /opt/codingteam/old-logs/;
+        index index.html;
+    }
 
-        location / {
-                 proxy_set_header X-Forwarded-Host $host;
-                 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-                 proxy_set_header X-Forwarded-Proto $scheme;
-                 proxy_set_header Host codingteam.org.ru;
-                 proxy_http_version 1.1;
-                 proxy_pass http://localhost:5000/;
-        }
+    location / {
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Host codingteam.org.ru;
+        proxy_http_version 1.1;
+        proxy_pass http://localhost:5000/;
+    }
 }
 
 server {
-	listen 80;
-	server_name codingteam.org.ru;
+    listen 80;
+    server_name codingteam.org.ru;
 
-	location / {
-		 rewrite ^(.*)$ https://codingteam.org.ru$1 permanent;
-	}
+    location / {
+         rewrite ^(.*)$ https://codingteam.org.ru$1 permanent;
+    }
 }


### PR DESCRIPTION
This is a dependency for https://github.com/codingteam/codingteam.org.ru/issues/62.

Also I've fixed the indentation in the file a bit.

Logs are already deployed and this configuration is already applied to the server.

Scope: #16.