### PR TITLE
chat-linker: update to 1.0.0

### DIFF
--- a/omnissiah/chat-linker/Dockerfile
+++ b/omnissiah/chat-linker/Dockerfile
@@ -1,6 +1,6 @@
-FROM node:6.10.2-alpine
+FROM node:8.7.0-alpine
 RUN apk update && apk add git
-RUN git clone https://github.com/jt3k/chat-linker.git /usr/app/src && cd /usr/app/src && git checkout df168c4ffb0922c494bb27f7b84780c854ea9b40
+RUN git clone https://github.com/jt3k/chat-linker.git /usr/app/src && cd /usr/app/src && git checkout ed96838bac33ff73b0de7f60c9c1417147cb4b5e
 RUN cd /usr/app/src && npm install # TODO: Not stable enough; migrate to yarn
 COPY app-config.json /usr/app/src/app-config.json
 WORKDIR /usr/app/src


### PR DESCRIPTION
This version of chat-linker will post stickers in for of emoticons (see https://github.com/jt3k/chat-linker/issues/39).