### PR TITLE
loglist: set up user and group for the used directories

### DIFF
--- a/xmpp2/loglist.yml
+++ b/xmpp2/loglist.yml
@@ -45,6 +45,8 @@
         path: '{{ item }}'
         state: directory
         mode: 'u=rx,go='
+        owner: root
+        group: root
       loop:
         - '{{ host_db_init_scripts_dir }}'
         - '{{ host_config_dir }}'
@@ -54,6 +56,8 @@
         path: '{{ item }}'
         state: directory
         mode: 'u=rwx,go='
+        owner: root
+        group: root
       loop:
         - '{{ host_data_dir }}'
 


### PR DESCRIPTION
Otherwise, the files were marked as owned by `dnsmasq:systemd-journal` (WTF), and this was breaking the PostgreSQL file access.

(Why can't `root` that runs `docker` files owned by `dnsmasq:systemd-journal` is also a mystery.)